### PR TITLE
Remove capybara-firebug dependency

### DIFF
--- a/konacha.gemspec
+++ b/konacha.gemspec
@@ -24,7 +24,6 @@ the asset pipeline and engines.}
   gem.add_dependency "capybara"
 
   gem.add_development_dependency "rspec-rails"
-  gem.add_development_dependency "capybara-firebug", "~> 1.1"
   gem.add_development_dependency "coffee-script"
   gem.add_development_dependency "ejs"
 end


### PR DESCRIPTION
Let's avoid extra dependencies to make Konacha as contributor-friendly
as possible.
