### PR TITLE
Rename basename to asset_name

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 # master
 
 * Support foo_spec.coffee files (without .js)
+* Rename Konacha::Spec#basename to #asset_name
 
 # 0.9.0
 

--- a/app/models/konacha/spec.rb
+++ b/app/models/konacha/spec.rb
@@ -4,8 +4,8 @@ module Konacha
       Konacha.spec_paths.map { |path| new(path) }
     end
 
-    def self.find(basename)
-      all.find { |spec| spec.basename == basename }
+    def self.find(asset_name)
+      all.find { |spec| spec.asset_name == asset_name }
     end
 
     attr_accessor :path
@@ -15,10 +15,10 @@ module Konacha
     end
 
     def url
-      "/#{basename}"
+      "/#{asset_name}"
     end
 
-    def basename
+    def asset_name
       path.sub(/(\.js|\.coffee).*/, '')
     end
   end

--- a/app/views/konacha/specs/index.html.erb
+++ b/app/views/konacha/specs/index.html.erb
@@ -1,1 +1,1 @@
-<%= javascript_include_tag *@specs.map(&:basename) %>
+<%= javascript_include_tag *@specs.map(&:asset_name) %>

--- a/app/views/konacha/specs/show.html.erb
+++ b/app/views/konacha/specs/show.html.erb
@@ -1,1 +1,1 @@
-<%= javascript_include_tag @spec.basename %>
+<%= javascript_include_tag @spec.asset_name %>

--- a/spec/controllers/specs_controller_spec.rb
+++ b/spec/controllers/specs_controller_spec.rb
@@ -30,13 +30,13 @@ describe Konacha::SpecsController do
   end
 
   describe "#show" do
-    it "finds the spec with the given basename and assigns it to @spec" do
+    it "finds the spec with the given asset_name and assigns it to @spec" do
       Konacha::Spec.should_receive(:find).with("array_spec") { :spec }
       get :show, :spec => "array_spec"
       assigns[:spec].should == :spec
     end
 
-    it "404s if there is no spec with the given basename" do
+    it "404s if there is no spec with the given asset_name" do
       Konacha::Spec.should_receive(:find).with("array_spec") { nil }
       get :show, :spec => "array_spec"
       response.status.should == 404

--- a/spec/models/spec_spec.rb
+++ b/spec/models/spec_spec.rb
@@ -1,18 +1,18 @@
 require 'spec_helper'
 
 describe Konacha::Spec do
-  describe "#basename" do
-    it "is the basename of the path" do
-      described_class.new("array_spec.js").basename.should == "array_spec"
-      described_class.new("array_spec.coffee").basename.should == "array_spec"
+  describe "#asset_name" do
+    it "is the asset_name of the path" do
+      described_class.new("array_spec.js").asset_name.should == "array_spec"
+      described_class.new("array_spec.coffee").asset_name.should == "array_spec"
     end
 
     it "ignores multiple extensions" do
-      described_class.new("array_spec.js.coffee").basename.should == "array_spec"
+      described_class.new("array_spec.js.coffee").asset_name.should == "array_spec"
     end
 
     it "includes relative path" do
-      described_class.new("subdirectory/array_spec.js").basename.should == "subdirectory/array_spec"
+      described_class.new("subdirectory/array_spec.js").asset_name.should == "subdirectory/array_spec"
     end
   end
 
@@ -31,7 +31,7 @@ describe Konacha::Spec do
   end
 
   describe ".find" do
-    it "returns the Spec with the given basename" do
+    it "returns the Spec with the given asset_name" do
       all = [described_class.new("a_spec.js"),
              described_class.new("b_spec.js")]
       described_class.should_receive(:all) { all }

--- a/spec/views/specs/index.html.erb_spec.rb
+++ b/spec/views/specs/index.html.erb_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe "konacha/specs/index" do
-  it "renders a script tag for each basename in @specs" do
-    a_spec = stub(:basename => "a_spec")
-    b_spec = stub(:basename => "b_spec")
+  it "renders a script tag for each asset_name in @specs" do
+    a_spec = stub(:asset_name => "a_spec")
+    b_spec = stub(:asset_name => "b_spec")
     assign(:specs, [a_spec, b_spec])
     render
     rendered.should have_selector("script[src='/assets/a_spec.js']")

--- a/spec/views/specs/show.html.erb_spec.rb
+++ b/spec/views/specs/show.html.erb_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe "konacha/specs/show" do
-  it "renders a script tag for @spec basename" do
-    spec = stub(:basename => "spec")
+  it "renders a script tag for @spec asset_name" do
+    spec = stub(:asset_name => "spec")
     assign(:spec, spec)
     render
     rendered.should have_selector("script[src='/assets/spec.js']")


### PR DESCRIPTION
This avoids confusion with File.basename, which has a different meaning.

---

Unless you have a better idea for the name? The regex was simply

```
perl -pi -e 's/basename/asset_name/g' **/*rb
```
