### PR TITLE
Do not time out after 300 seconds

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 # master
 
+* Do not time out after 300 seconds
+
 # 0.10.0
 
 * Rename `konacha:ci` and `konacha:server` task to `konacha:run` and

--- a/lib/konacha/runner.rb
+++ b/lib/konacha/runner.rb
@@ -52,18 +52,15 @@ module Konacha
       def run_examples!
         session.visit(spec.url)
 
-        previous_results = ""
-
-        session.wait_until(300) do
+        dots_printed = 0
+        begin
+          sleep 0.2
+          done = session.evaluate_script('Konacha.done')
           dots = session.evaluate_script('Konacha.dots')
-          io.print dots.sub(/^#{Regexp.escape(previous_results)}/, '')
+          io.write dots[dots_printed..-1]
           io.flush
-          previous_results = dots
-          session.evaluate_script('Konacha.done')
-        end
-
-        dots = session.evaluate_script('Konacha.dots')
-        io.print dots.sub(/^#{Regexp.escape(previous_results)}/, '')
+          dots_printed = dots.length
+        end until done
 
         @examples = JSON.parse(session.evaluate_script('Konacha.getResults()')).map do |row|
           Example.new(row)


### PR DESCRIPTION
Timeouts like this should normally go into a build server.

Mocha times out asynchronous tests after 2000ms by default, and
Webdriver throws exceptions when the browser connection goes funny, so
there is no obvious reason to expect hangs.

This also avoids Capybara's wait_until, which is going away in Capybara
2.0.
