### PR TITLE
Provide more informative failure messages in konacha:runner

### DIFF
--- a/lib/konacha/runner.rb
+++ b/lib/konacha/runner.rb
@@ -99,8 +99,22 @@ module Konacha
         msg = []
         msg << "  Failed: #{@row['name']}"
         msg << "    #{@row['message']}"
-        msg << "    in #{@row['trace']['fileName']}:#{@row['trace']['lineNumber']}" if @row['trace']
-        msg.join("\n")
+        msg << failure_additional_info
+        msg.compact.join("\n")
+      end
+    end
+
+    def failure_additional_info
+      trace = @row['trace'] || {}
+      if trace =~ /timeout of [\d\.]+ms exceeded/
+        "Execution of spec took too long (or forgot to call done())"
+      elsif trace['fileName'].present?
+        # TODO: Investigate if mocha even returns errors with fileName and 
+        #       lineNumber
+        #
+        #      - I've seen @row["trace"] coming back as a straight strings
+        #         instead of hashes
+        "    in: #{[trace['fileName'],trace['lineNumber']].compact.join(":")}"
       end
     end
   end

--- a/spec/dummy/spec/javascripts/spec_helper_spec.js
+++ b/spec/dummy/spec/javascripts/spec_helper_spec.js
@@ -3,5 +3,5 @@
 describe("two_plus_two", function(){
   it("equals four", function(){
     two_plus_two().should.equal(4);
-  })
+  });
 });

--- a/spec/konacha/example_spec.rb
+++ b/spec/konacha/example_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Konacha::Example do
+  def trace(opts = {})
+    { "trace" => opts }
+  end
+
+  context "without additional failure info" do
+    it "should not have an extra empty row" do
+      ex = Konacha::Example.new({'message' => 'foo'})
+      ex.failure_message.split("\n").count.should be 2
+    end
+  end
+
+  it "should provide extra context for timeouts" do
+    ex = Konacha::Example.new(trace("timeout of 2000ms exceeded"))
+    ex.failure_message.should match "Execution of spec took too long"
+    ex.failure_message.should match "or forgot to call done"
+  end
+
+  it "should provide a prettified location when fileName is present" do
+    ex = Konacha::Example.new(trace("fileName" => "foo", "lineNumber" => 42))
+    ex.failure_message.should match "in: foo:42"
+  end
+end


### PR DESCRIPTION
Hey folks, I had some ideas after looking at Issue #19 on how to improve error runner messaging.
- When timeouts occur suggest that done() may not have
  been called
- Show filename and optionally append line number if present
- Don't show extra failure info if none is present

Now error messages will be formated like this:

``` plaintext
  Failed: <test name>
    <failure message>
    in: <fileName>(:<lineNumber>)? | Execution of spec took too long (or forgot to call done()) | _nothing_
```

What do you think?
