### PR TITLE
Fixes issue #28 Errors using the :webkit driver

### DIFF
--- a/lib/konacha/runner.rb
+++ b/lib/konacha/runner.rb
@@ -74,9 +74,11 @@ module Konacha
       begin
         sleep 0.1
         done, dots = session.evaluate_script('[Konacha.done, Konacha.dots]')
-        io.write dots[dots_printed..-1]
-        io.flush
-        dots_printed = dots.length
+        if dots
+          io.write dots[dots_printed..-1]
+          io.flush
+          dots_printed = dots.length
+        end
       end until done
 
       @examples = JSON.parse(session.evaluate_script('Konacha.getResults()')).map do |row|


### PR DESCRIPTION
This patch fixes the issue that is brought up when using the capybara-webkit driver. The runner is trying to print out dots to the screen, but the driver has not set any dots yet, resulting in the following null error:

```
rake konacha:run --trace
** Invoke konacha:run (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute konacha:run
............................rake aborted!
undefined method `[]' for nil:NilClass
/Users/markbates/development/gemdev/konacha/lib/konacha/runner.rb:77:in `run'
/Users/markbates/development/gemdev/konacha/lib/konacha/runner.rb:18:in `block in run'
/Users/markbates/development/gemdev/konacha/lib/konacha/runner.rb:18:in `each'
/Users/markbates/development/gemdev/konacha/lib/konacha/runner.rb:18:in `run'
/Users/markbates/development/gemdev/konacha/lib/konacha/runner.rb:6:in `start'
/Users/markbates/development/gemdev/konacha/lib/konacha.rb:18:in `run'
/Users/markbates/Dropbox/development/gemdev/konacha/lib/tasks/konacha.rake:9:in `block (2 levels) in <top (required)>'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `call'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `block in execute'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `each'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `execute'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/task.rb:158:in `block in invoke_with_call_chain'
/Users/markbates/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/task.rb:144:in `invoke'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/application.rb:116:in `invoke_task'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block (2 levels) in top_level'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `each'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block in top_level'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/application.rb:88:in `top_level'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/application.rb:66:in `block in run'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/application.rb:63:in `run'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/bin/rake:33:in `<top (required)>'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/bin/rake:19:in `load'
/Users/markbates/.rvm/gems/ruby-1.9.3-p194@global/bin/rake:19:in `<main>'
Tasks: TOP => konacha:run
```
