### PR TITLE
Ability to toggle TDD-mode of mocha

### DIFF
--- a/lib/assets/javascripts/konacha/runner.js
+++ b/lib/assets/javascripts/konacha/runner.js
@@ -2,7 +2,7 @@ window.Konacha = {
   dots:"",
 
   mochaOptions: {
-    ui: 'bdd',
+    ui: 'tdd',
 
     reporter: function (runner) {
       window.mocha.reporters.Base.call(this, runner);

--- a/lib/assets/javascripts/konacha/server.js
+++ b/lib/assets/javascripts/konacha/server.js
@@ -1,6 +1,6 @@
 window.Konacha = {
   mochaOptions: {
-    ui: 'bdd',
+    ui: 'tdd',
     reporter: mocha.reporters.HTML
   }
 };


### PR DESCRIPTION
I really like konacha, it's an excellent tool! However, I also like the tdd-style that mocha provides and it would be great if I could use them together.

This isn't a working implementation, but I thought I'd open a pull request to see if this could be accepted when it's working properly? (and also to get some help) 

A few questions:
- My idea of toggling would be to change `runner|server.js` into `runner|server.js.erb`, and adding a config setting to Konacha where one can optionally choose 'tdd'. Does that sound like a good idea?
- When setting to TDD statically (see the first commit), `rake konacha:run` throws `undefined|0|ReferenceError: Can't find variable: beforeEach`. What could be the reason to this?
