### PR TITLE
Individual specs can now be run using the konacha:run task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,25 @@ describe "Array#sum", ->
     [1,2,3].sum().should.equal(6)
 ```
 
+## Running (Rake Tasks)
+
+### `rake konacha:serve`
+
 The `konacha:serve` rake task starts a server for your tests. You can go to the root
 page to run all specs (e.g. `http://localhost:3500/`), a sub page to run an individual
 spec file (e.g. `http://localhost:3500/array_sum_spec`), or a path to a subdirectory to
 run a subset of specs (e.g. `http://localhost:3500/models`).
 
-Alternatively, you can run the specs in your shell with the `konacha:run` task.
+### `rake konacha:run`
+
+The `konacha:run` rake task will let you run your tests from the command line.
+
+To an individual spec, or specs, you can pass a comma seperated list of specs via the `SPEC` parameter
+
+```
+$ rake konacha:run SPEC=foo_spec
+$ rake konacha:run SPEC=foo_spec,bar_spec,etc_spec
+```
 
 ## Spec Helper
 

--- a/app/models/konacha/spec.rb
+++ b/app/models/konacha/spec.rb
@@ -4,7 +4,11 @@ module Konacha
     end
 
     def self.all
-      Konacha.spec_paths.map { |path| new(path) }
+      paths = Konacha.spec_paths
+      if ENV["SPEC"]
+        paths =  ENV["SPEC"].split(",")
+      end
+      paths.map {|path| new(path)}
     end
 
     def self.find(path)

--- a/spec/models/spec_spec.rb
+++ b/spec/models/spec_spec.rb
@@ -28,6 +28,15 @@ describe Konacha::Spec do
       all = described_class.all
       all.length.should == 2
     end
+
+    it "returns specs passed via the ENV['spec'] parameter" do
+      ENV["SPEC"] = "foo_spec,bar_spec,baz_spec"
+      all = described_class.all
+      all.length.should == 3
+      paths = all.map {|p| p.path}
+      paths =~ %w{foo_spec bar_spec baz_spec}
+      ENV["SPEC"] = nil
+    end
   end
 
   describe ".find" do


### PR DESCRIPTION
Added the ability to pass in one or more specs to the konacha:run task to be run from the command line instead of the whole test suite. This will be helpful for people who run guard and other background test runners.

I'm doing this via a pull request, since it's my first direct commit to the repo, and I want to make sure everything looks good to everyone else, before I merge it in.
