### PR TITLE
Don't depend on `rails` since it will require activerecord

### DIFF
--- a/konacha.gemspec
+++ b/konacha.gemspec
@@ -30,4 +30,5 @@ the asset pipeline and engines.}
   gem.add_development_dependency "coffee-script"
   gem.add_development_dependency "ejs"
   gem.add_development_dependency "vendorer"
+  gem.add_development_dependency "tzinfo"
 end


### PR DESCRIPTION
This behavior is not desirable when using `nosql` like mongoid, since it will ask you for a `activerecord-sqlite3-adapter`.
