### PR TITLE
Plugged my gem that adds chai-jquery plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Konacha will make all three of chai's assertion styles available to you: `expect
 `should`, and `assert`. See the chai documentation for the details.
 
 If you use jQuery, you may want to check out [chai-jquery](https://github.com/jfirebaugh/chai-jquery)
-for some jQuery-specific assertions.
+for some jQuery-specific assertions. You can add it painlessly with the
+[chai-jquery-rails](https://github.com/wordofchristian/chai-jquery-rails) gem.
 
 ## Transactions
 


### PR DESCRIPTION
I couldn't find a gem to add the chai-jquery plugin and I didn't want to use a submodule, so the [chai-jquery-rails](https://github.com/wordofchristian/chai-jquery-rails) gem was born. I've added a reference to it in the Readme. 
