### PR TITLE
Remove konacha_config.js and Konacha.mochaOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ As of Konacha 2.0, your tests are run inside an iframe. See the section
 "[Using the DOM](#using-the-dom)" for details. You may be able to upgrade
 without any changes to your test code.
 
+As of Konacha 2.0, a `konacha_config.js` or `konacha_config.js.coffee` file
+is no longer automatically included, and `Konacha.mochaOptions` no longer
+exists. Instead, use a [`spec_helper.js`](#spec-helper) and mocha's chainable setup
+methods.
+
 ## Installation
 
 Add konacha to the `:test` and `:development` groups in the Gemfile and `bundle install`:
@@ -127,6 +132,19 @@ describe("Array#sum", function() {
 The `spec_helper` is a good place to set Mocha and Chai options as well, for instance:
 
 ```javascript
+// set the Mocha test interface
+// see http://visionmedia.github.com/mocha/#interfaces
+mocha.ui('bdd');
+
+// ignore the following globals during leak detection
+mocha.globals(['YUI']);
+
+// or, ignore all leaks
+mocha.ignoreLeaks();
+
+// set slow test timeout in ms
+mocha.timeout(5);
+
 // Show stack trace on failing assertion.
 chai.Assertion.includeStack = true;
 ```
@@ -165,29 +183,6 @@ The `stylesheets` option sets the stylesheets to be linked from the `<head>`
 of the test runner iframe.
 
 The values above are the defaults.
-
-### Mocha Configuration
-
-You can customize the Mocha options passed into `mocha.setup(..)` by creating a file
-named `konacha_config.js` or `konacha_config.js.coffee` in `spec/javascripts` and
-setting properties of `Konacha.mochaOptions`:
-
-```javascript
-// set the Mocha test interface
-// see http://visionmedia.github.com/mocha/#interfaces
-Konacha.mochaOptions.ui = 'bdd';
-
-// ignore the following globals during leak detection
-Konacha.mochaOptions.globals = ['YUI'];
-
-// or, ignore all leaks
-Konacha.mochaOptions.ignoreLeaks = true;
-
-// set slow test timeout in ms
-Konacha.mochaOptions.timeout = 5;
-```
-
-The `ui` and `reporter` Mocha options are set by Konacha and must not be modified.
 
 ## Test Interface and Assertions
 

--- a/app/views/konacha/specs/specs.html.erb
+++ b/app/views/konacha/specs/specs.html.erb
@@ -10,8 +10,6 @@
     <% end %>
 
     <%= javascript_include_tag "mocha", "chai", "konacha/#{Konacha.mode}", :debug => false %>
-    <%= javascript_include_tag("konacha_config", :debug => false) if Rails.application.assets.find_asset('konacha_config') %>
-    <%= javascript_include_tag "konacha", :debug => false %>
 
     <%= spec_include_tag *@specs %>
   </head>

--- a/lib/assets/javascripts/konacha.js
+++ b/lib/assets/javascripts/konacha.js
@@ -1,4 +1,11 @@
-mocha.setup(Konacha.mochaOptions);
+mocha.ui('bdd');
+
+window.Konacha = {
+  reset: function() {
+    document.body = document.createElement('body');
+    document.body.id = 'konacha';
+  }
+};
 
 mocha.suite.beforeEach(function () {
   Konacha.reset();

--- a/lib/assets/javascripts/konacha/common.js
+++ b/lib/assets/javascripts/konacha/common.js
@@ -1,6 +1,0 @@
-window.Konacha = {
-  reset: function() {
-    document.body = document.createElement('body');
-    document.body.id = 'konacha';
-  }
-};

--- a/lib/assets/javascripts/konacha/runner.js
+++ b/lib/assets/javascripts/konacha/runner.js
@@ -1,50 +1,46 @@
-//= require konacha/common
+//= require konacha
 
 Konacha.dots = "";
-
-Konacha.mochaOptions = {
-  ui: 'bdd',
-
-  reporter: function(runner) {
-    window.mocha.reporters.Base.call(this, runner);
-
-    runner.on('start', function() {
-      Konacha.results = [];
-    });
-
-    runner.on('pass', function(test) {
-      Konacha.dots += ".";
-      Konacha.results.push({
-        name:test.title,
-        passed:true
-      });
-    });
-
-    runner.on('fail', function(test) {
-      Konacha.dots += "F";
-      Konacha.results.push({
-        name:test.title,
-        passed:false,
-        message:test.err.message,
-        trace:test.err.stack
-      });
-    });
-
-    runner.on('pending', function(test) {
-      Konacha.dots += "P";
-      Konacha.results.push({
-        name:test.title,
-        passed:false,
-        pending:true
-      });
-    });
-
-    runner.on('end', function() {
-      Konacha.done = true;
-    });
-  }
-};
 
 Konacha.getResults = function() {
   return JSON.stringify(Konacha.results);
 };
+
+mocha.reporter(function(runner) {
+  Mocha.reporters.Base.call(this, runner);
+
+  runner.on('start', function() {
+    Konacha.results = [];
+  });
+
+  runner.on('pass', function(test) {
+    Konacha.dots += ".";
+    Konacha.results.push({
+      name:test.title,
+      passed:true
+    });
+  });
+
+  runner.on('fail', function(test) {
+    Konacha.dots += "F";
+    Konacha.results.push({
+      name:test.title,
+      passed:false,
+      message:test.err.message,
+      trace:test.err.stack
+    });
+  });
+
+  runner.on('pending', function(test) {
+    Konacha.dots += "P";
+    Konacha.results.push({
+      name:test.title,
+      passed:false,
+      pending:true
+    });
+  });
+
+  runner.on('end', function() {
+    Konacha.done = true;
+  });
+});

--- a/lib/assets/javascripts/konacha/server.js
+++ b/lib/assets/javascripts/konacha/server.js
@@ -1,11 +1,6 @@
-//= require konacha/common
+//= require konacha
 
-Konacha.mochaOptions = {
-  ui: 'bdd',
-
-  reporter: function(runner) {
-    var reporterRoot = parent.document.getElementById('mocha');
-
-    return mocha.reporters.HTML(runner, reporterRoot);
-  }
-};
+mocha.reporter(function(runner) {
+  var reporterRoot = parent.document.getElementById('mocha');
+  return Mocha.reporters.HTML(runner, reporterRoot);
+});

--- a/spec/dummy/spec/javascripts/konacha_config.js
+++ b/spec/dummy/spec/javascripts/konacha_config.js
@@ -1,2 +1,0 @@
-// ignore the following globals during leak detection
-Konacha.mochaOptions.globals = ['YUI'];

--- a/spec/dummy/spec/javascripts/konacha_config_spec.js
+++ b/spec/dummy/spec/javascripts/konacha_config_spec.js
@@ -1,9 +1,0 @@
-//= require spec_helper
-
-describe("Konacha.mochaOptions", function(){
-  it("overrides the default globals ignore", function(){
-    var options = Konacha.mochaOptions;
-    options.globals.should.not.be.undefined;
-    options.globals.should.eql(['YUI']);
-  });
-});

--- a/vendor/assets/javascripts/mocha.js
+++ b/vendor/assets/javascripts/mocha.js
@@ -998,7 +998,7 @@ function Mocha(options) {
   this.suite = new exports.Suite('', new exports.Context);
   this.ui(options.ui);
   this.reporter(options.reporter);
-  if (options.timeout) this.suite.timeout(options.timeout);
+  if (options.timeout) this.timeout(options.timeout);
 }
 
 /**
@@ -1014,16 +1014,20 @@ Mocha.prototype.addFile = function(file){
 };
 
 /**
- * Set reporter to `name`, defaults to "dot".
+ * Set reporter to `reporter`, defaults to "dot".
  *
- * @param {String} name
+ * @param {String|Function} reporter name of a reporter or a reporter constructor
  * @api public
  */
 
-Mocha.prototype.reporter = function(name){
-  name = name || 'dot';
-  this._reporter = require('./reporters/' + name);
-  if (!this._reporter) throw new Error('invalid reporter "' + name + '"');
+Mocha.prototype.reporter = function(reporter){
+  if ('function' == typeof reporter) {
+    this._reporter = reporter;
+  } else {
+    reporter = reporter || 'dot';
+    this._reporter = require('./reporters/' + reporter);
+    if (!this._reporter) throw new Error('invalid reporter "' + reporter + '"');
+  }
   return this;
 };
 
@@ -1146,6 +1150,18 @@ Mocha.prototype.growl = function(){
 
 Mocha.prototype.globals = function(globals){
   this.options.globals = globals;
+  return this;
+};
+
+/**
+ * Set the timeout in milliseconds.
+ *
+ * @param {Number} timeout
+ * @return {Mocha}
+ * @api public
+ */
+Mocha.prototype.timeout = function(timeout){
+  this.suite.timeout(timeout);
   return this;
 };
 
@@ -4573,20 +4589,13 @@ process.on = function(e, fn){
   }
 };
 
-/**
- * Expose mocha.
- */
-
-window.mocha = require('mocha');
-
 // boot
 ;(function(){
-  var utils = mocha.utils
-    , options = {}
-
-  // TODO: use new Mocha here... not mocha.grep etc
-
-  mocha.suite = new mocha.Suite('', new mocha.Context());
+  /**
+   * Expose mocha.
+   */
+  var Mocha = window.Mocha = require('mocha'),
+      mocha = window.mocha = new Mocha({reporter: 'html'});
 
   /**
    * Highlight the given string of `js`.
@@ -4620,7 +4629,7 @@ window.mocha = require('mocha');
    */
 
   function parse(qs) {
-    return utils.reduce(qs.replace('?', '').split('&'), function(obj, pair){
+    return Mocha.utils.reduce(qs.replace('?', '').split('&'), function(obj, pair){
       var i = pair.indexOf('=')
         , key = pair.slice(0, i)
         , val = pair.slice(++i);
@@ -4631,11 +4640,28 @@ window.mocha = require('mocha');
   }
 
   /**
-   * Grep.
+   * For backward compatibility from when window.mocha was actually
+   * the `Mocha` export.
+   */
+  mocha.utils      = Mocha.utils;
+  mocha.interfaces = Mocha.interfaces;
+  mocha.reporters  = Mocha.reporters;
+  mocha.Runnable   = Mocha.Runnable;
+  mocha.Context    = Mocha.Context;
+  mocha.Runner     = Mocha.Runner;
+  mocha.Suite      = Mocha.Suite;
+  mocha.Hook       = Mocha.Hook;
+  mocha.Test       = Mocha.Test;
+
+  /**
+   * Override ui to ensure that the ui functions are initialized.
+   * Normally this would happen in Mocha.prototype.loadFiles.
    */
 
-  mocha.grep = function(str){
-    options.grep = new RegExp(utils.escapeRegexp(str));
+  mocha.ui = function(ui) {
+    Mocha.prototype.ui.call(this, ui);
+    this.suite.emit('pre-require', window, null, this);
+    return this;
   };
 
   /**
@@ -4643,14 +4669,9 @@ window.mocha = require('mocha');
    */
 
   mocha.setup = function(opts){
-    if ('string' === typeof opts) options.ui = opts;
-    else options = opts;
-
-    ui = mocha.interfaces[options.ui];
-    if (!ui) throw new Error('invalid mocha interface "' + ui + '"');
-    if (options.timeout) mocha.suite.timeout(options.timeout);
-    ui(mocha.suite);
-    mocha.suite.emit('pre-require', window, null, mocha);
+    if ('string' === typeof opts) opts = {ui: opts};
+    for (var opt in opts) this[opt](opts[opt]);
+    return this;
   };
 
   /**
@@ -4658,18 +4679,17 @@ window.mocha = require('mocha');
    */
 
   mocha.run = function(fn){
-    mocha.suite.emit('run');
-    var runner = new mocha.Runner(mocha.suite);
-    var Reporter = options.reporter || mocha.reporters.HTML;
-    var reporter = new Reporter(runner);
+    var options = this.options;
+    options.globals = options.globals || [];
+    options.globals.push('location');
+
     var query = parse(window.location.search || "");
-    if (query.grep) runner.grep(new RegExp(query.grep));
-    if (options.grep) runner.grep(options.grep);
-    if (options.ignoreLeaks) runner.ignoreLeaks = true;
-    if (options.globals) runner.globals(options.globals);
-    runner.globals(['location']);
-    runner.on('end', highlightCode);
-    return runner.run(fn);
+    if (query.grep) this.grep(query.grep);
+
+    return Mocha.prototype.run.call(this, function () {
+      highlightCode();
+      if (fn) fn();
+    });
   };
 })();
 })();


### PR DESCRIPTION
I'd like this breaking change to go into 2.0.

Once mocha supports the chainable setup methods in the browser (https://github.com/visionmedia/mocha/issues/562) and a configurable reporter (https://github.com/visionmedia/mocha/issues/563) everything you can accomplish in a konacha_config.js can be done in a spec_helper.js instead.
