### PR TITLE
Expose spec path to reporter

### DIFF
--- a/app/assets/javascripts/konacha/runner.js
+++ b/app/assets/javascripts/konacha/runner.js
@@ -11,7 +11,8 @@ mocha.reporter(function(runner) {
       fullTitle:test.fullTitle(),
       duration:test.duration,
       parentFullTitle:test.parent.fullTitle(),
-      status:status
+      status:status,
+      path:test.parent.path
     };
 
     if (status == "failed")
@@ -21,9 +22,14 @@ mocha.reporter(function(runner) {
   };
 
   var createSuiteObject = function(suite) {
+    // We need to propagate the path down the suite tree
+    if (suite.parent)
+      suite.path = suite.parent.path;
+
     var obj = {
       title:suite.title,
-      fullTitle:suite.fullTitle()
+      fullTitle:suite.fullTitle(),
+      path:suite.path
     };
 
     if (suite.parent)

--- a/lib/konacha/reporter/metadata.rb
+++ b/lib/konacha/reporter/metadata.rb
@@ -24,8 +24,7 @@ module Konacha
       end
 
       def file_path
-        STDERR.puts "file_path not implemented" if Konacha.config.verbose
-        "" # RSpec's BaseFormatter expects the return value to be a string
+        data['path']
       end
 
       alias_method :location, :file_path

--- a/spec/reporter/metadata_spec.rb
+++ b/spec/reporter/metadata_spec.rb
@@ -52,17 +52,22 @@ describe Konacha::Reporter::Metadata do
     end
   end
 
-  describe "#description" do
-    it "looks for data['title']" do
-      subject.update('title' => 'super test')
-      subject.description.should == 'super test'
+  shared_examples_for "data delegation method" do |key, method|
+    it "returns data['#{key}']" do
+      subject.update(key => 'super test')
+      subject.send(method).should == 'super test'
     end
   end
 
+  describe "#file_path" do
+    it_behaves_like "data delegation method", "path", "file_path"
+  end
+
+  describe "#description" do
+    it_behaves_like "data delegation method", "title", "description"
+  end
+
   describe "#full_description" do
-    it "looks for data['fullTitle']" do
-      subject.update('fullTitle' => 'super test')
-      subject.full_description.should == 'super test'
-    end
+    it_behaves_like "data delegation method", "fullTitle", "full_description"
   end
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -32,7 +32,8 @@ describe Konacha::Runner do
        'type' => 'suite',
        'data' => {
          'title' => 'failure',
-         'fullTitle' => 'failure'
+         'fullTitle' => 'failure',
+         'path' => 'failing_spec.js'
        }}
     end
 
@@ -41,7 +42,8 @@ describe Konacha::Runner do
        'type' => 'suite',
        'data' => {
          'title' => 'failure',
-         'fullTitle' => 'failure'
+         'fullTitle' => 'failure',
+         'path' => 'failing_spec.js'
        }}
     end
 
@@ -51,7 +53,8 @@ describe Konacha::Runner do
        'data'  => {
          'title'           => 'fails',
          'fullTitle'       => 'failure fails',
-         'parentFullTitle' => 'failure'}}
+         'parentFullTitle' => 'failure',
+         'path'            => 'failing_spec.js'}}
     end
 
     let(:failure) do
@@ -62,6 +65,7 @@ describe Konacha::Runner do
          'fullTitle'       => 'failure fails',
          'parentFullTitle' => 'failure',
          'status'          => 'failed',
+         'path'            => 'failing_spec.js',
          'error'           => {'message' => 'expected 4 to equal 5', 'expected' => 5}}}
     end
 
@@ -73,6 +77,7 @@ describe Konacha::Runner do
          'fullTitle'       => 'the body#konacha element is empty',
          'parentFullTitle' => 'the body#konacha element',
          'status'          => 'passed',
+         'path'            => 'body_spec.js.coffee',
          'duration'        => anything}}
     end
 
@@ -83,6 +88,7 @@ describe Konacha::Runner do
          'title'           => 'is pending',
          'fullTitle'       => 'pending test is pending',
          'parentFullTitle' => 'pending test',
+         'path'            => 'pending_spec.js',
          'status'          => 'pending'}}
     end
 


### PR DESCRIPTION
Since we're storing the spec path on the mocha.suite object we can pass it back to the Ruby layer when we send events to the runner/reporter.

This is useful for formatters that display the spec path when an error occurs (RSpec's ProgressFormatter, for instance).
