### PR TITLE
Introduce konacha-chai-matchers for chai-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,11 @@ Konacha will make all three of chai's assertion styles available to you: `expect
 `should`, and `assert`. See the chai documentation for the details.
 
 If you use jQuery, you may want to check out [chai-jquery](https://github.com/jfirebaugh/chai-jquery)
-for some jQuery-specific assertions. You can add it painlessly with the
-[chai-jquery-rails](https://github.com/wordofchristian/chai-jquery-rails) gem.
+for some jQuery-specific assertions. There are a lot of interesting chai
+matchers out there, see [the chai plugins page](http://chaijs.com/plugins)
+
+To make all these available for your konacha environment, see the
+[Konacha-chai-matchers gem](https://github.com/matthijsgroen/konacha-chai-matchers)
 
 ## Templates / Fixtures
 


### PR DESCRIPTION
A single gem to get access to all chai matcher plugins
