### PR TITLE
Support files with periods in the filename

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Konacha::Engine.routes.draw do
-  get '/iframe/*name' => 'specs#iframe', :as => :iframe
+  get '/iframe/*name' => 'specs#iframe', :format => false, :as => :iframe
   get '/'             => 'specs#parent'
   get '*path'         => 'specs#parent'
 end

--- a/spec/dummy/spec/javascripts/jquery.plugin_spec.js
+++ b/spec/dummy/spec/javascripts/jquery.plugin_spec.js
@@ -1,0 +1,4 @@
+describe('jQuery.fn.plugin()', function () {
+  it('is a fake test to assert that the suite has loaded into the iframe', function () {
+  });
+});

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -35,6 +35,12 @@ describe Konacha::Server, :type => :feature do
     page.should have_css(".test.pass")
   end
 
+  it "serves a file with a period in the name" do
+    visit "/jquery.plugin_spec"
+    page.should have_content("jQuery.fn.plugin()")
+    page.should have_css(".test.pass", :count => 1)
+  end
+
   it "supports spec helpers" do
     visit "/spec_helper_spec"
     page.should have_content("two_plus_two")


### PR DESCRIPTION
For example creating a spec file named _jquery.plugin_spec.js_ currently fails. Requesting the iframe at `/iframe/jquery.plugin_spec` returns a 404 due to the filename being truncated by the router.

This is fixed by disabling the :format parameter in the iframe route.
