### PR TITLE
Ensure that Konacha.getEvents always returns an Array

### DIFF
--- a/app/assets/javascripts/konacha/runner.js
+++ b/app/assets/javascripts/konacha/runner.js
@@ -1,6 +1,6 @@
 Konacha = {
   getEvents: function() {
-    return JSON.stringify(Konacha.events);
+    return JSON.stringify(Konacha.events || []);
   }
 };
 

--- a/lib/konacha/runner.rb
+++ b/lib/konacha/runner.rb
@@ -19,9 +19,8 @@ module Konacha
       events_consumed = 0
       done = false
       begin
-        sleep 0.1
         events = JSON.parse(session.evaluate_script('window.top.Konacha.getEvents()'))
-        if events
+        if events.present?
           events[events_consumed..-1].each do |event|
             done = true if event['event'] == 'end'
             reporter.process_mocha_event(event)


### PR DESCRIPTION
This was prompted by #98 but is probably a good idea in any case.

I suspect that this allows us to remove the `sleep 0.1` in `runner.rb`. @joliss, do you remember why this was added? It first appeared in 4a73478 as `sleep 0.2` and was decreased to `0.1` in d0f709f.
