### PR TITLE
Made port of the runner configurable

### DIFF
--- a/lib/konacha.rb
+++ b/lib/konacha.rb
@@ -29,7 +29,7 @@ module Konacha
       yield config
     end
 
-    delegate :port, :spec_dir, :spec_matcher, :application, :driver, :to => :config
+    delegate :port, :spec_dir, :spec_matcher, :application, :driver, :runner_port, :to => :config
 
     def spec_root
       File.join(Rails.root, config.spec_dir)

--- a/lib/konacha/engine.rb
+++ b/lib/konacha/engine.rb
@@ -34,6 +34,7 @@ module Konacha
       options.driver       ||= :selenium
       options.stylesheets  ||= %w(application)
       options.verbose      ||= false
+      options.runner_port  ||= nil
 
       app.config.assets.paths << app.root.join(options.spec_dir).to_s
     end

--- a/lib/konacha/runner.rb
+++ b/lib/konacha/runner.rb
@@ -3,6 +3,7 @@ require "capybara"
 module Konacha
   class Runner
     def self.start
+      Capybara.server_port = Konacha.runner_port
       new.run
     end
 

--- a/spec/konacha_spec.rb
+++ b/spec/konacha_spec.rb
@@ -15,6 +15,12 @@ describe Konacha do
         subject.spec_matcher.should == /_spec\.|_test\./
       end
     end
+
+    describe ".runner_port" do
+      it "defaults to nil" do
+        subject.runner_port.should == nil
+      end
+    end
   end
 
   describe ".spec_paths" do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -31,6 +31,14 @@ describe Konacha::Runner do
     end
   end
 
+  describe ".start" do
+    it 'sets the Capybara.server_port' do
+      Capybara.should_receive(:server_port=).with(Konacha.runner_port)
+      Konacha::Runner.any_instance.stub(:run)
+      Konacha::Runner.start
+    end
+  end
+
   shared_examples_for "Konacha::Runner" do |driver|
     before do
       Konacha.configure do |config|


### PR DESCRIPTION
This allows projects to change the port of the runner. I'm using this together with a fixed assets_host to generate absolute paths for some javascript files.

Usage:

``` ruby
Konacha.configure do |config|
  config.runner_port = 31337
end if defined?(Konacha)
```

Default behaviour remains the same.
