### PR TITLE
Make Konacha grep aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,11 @@ Konacha can be configured in an initializer, e.g. `config/initializers/konacha.r
 
 ```ruby
 Konacha.configure do |config|
-  config.spec_dir     = "spec/javascripts"
-  config.spec_matcher = /_spec\.|_test\./
-  config.driver       = :selenium
-  config.stylesheets  = %w(application)
+  config.spec_dir       = "spec/javascripts"
+  config.spec_matcher   = /_spec\.|_test\./
+  config.driver         = :selenium
+  config.stylesheets    = %w(application)
+  config.iframe_economy = false
 end if defined?(Konacha)
 ```
 
@@ -197,6 +198,24 @@ for the `run` task (try `:poltergeist`, after installing
 [PhantomJS](https://github.com/jonleighton/poltergeist#installing-phantomjs)).
 The `stylesheets` option sets the stylesheets to be linked from the `<head>`
 of the test runner iframe.
+
+The `iframe_economy` option tells Konacha to only load the required iframes.
+Even if you are running a single spec, Konacha by default loads all iframes
+and lets mocha determine whether to run a single test or all the suite.
+Setting `iframe_economy` to `true` tells Konacha to load a single iframe
+when running a single test, resulting in a faster page load for single tests.
+
+**Note:** If you want to use this option, you will
+need to name your spec files the same as your spec description.
+For example, the spec with file name `hello_world_spec.js" would need to start with:
+
+```javascript
+describe('Hello World', function() {
+  //... your tests here
+});
+```
+
+
 
 The values above are the defaults.
 

--- a/app/controllers/konacha/specs_controller.rb
+++ b/app/controllers/konacha/specs_controller.rb
@@ -6,7 +6,7 @@ module Konacha
 
     def parent
       @run_mode = params.fetch(:mode, Konacha.mode).to_s.inquiry
-      @specs = Konacha::Spec.all(params[:path])
+      @specs = Konacha::Spec.all(params[:path], params[:grep])
     end
 
     def iframe

--- a/app/models/konacha/spec.rb
+++ b/app/models/konacha/spec.rb
@@ -3,13 +3,19 @@ module Konacha
     class NotFound < StandardError
     end
 
-    def self.all(path = nil)
+    def self.all(path = nil, grep = nil)
       paths = Konacha.spec_paths
       paths = ENV["SPEC"].split(",") if ENV["SPEC"]
       paths = paths.map { |p| new(p) }
       if path.present?
-        paths = paths.select { |s| s.path.starts_with?(path) }.presence or raise NotFound
+        paths = paths.select { |s| s.path.starts_with?(path) }
       end
+      if Konacha.iframe_economy and grep.present?
+        paths = paths.select do |s|
+          s.grep_match(grep)
+        end
+      end
+      paths.presence or raise NotFound
       paths
     end
 
@@ -25,6 +31,11 @@ module Konacha
 
     def asset_name
       path.sub(/(\.js|\.coffee).*/, '')
+    end
+
+    def grep_match(grep)
+      asset = (asset_name.split("/").last.underscore + ".").sub(Konacha.spec_matcher, "")
+      grep.gsub(/\s/, "_").downcase.starts_with? asset
     end
   end
 end

--- a/lib/konacha.rb
+++ b/lib/konacha.rb
@@ -29,7 +29,7 @@ module Konacha
       yield config
     end
 
-    delegate :port, :spec_dir, :spec_matcher, :application, :driver, :runner_port, :to => :config
+    delegate :port, :spec_dir, :spec_matcher, :iframe_economy, :application, :driver, :runner_port, :to => :config
 
     def spec_root
       File.join(Rails.root, config.spec_dir)

--- a/lib/konacha/engine.rb
+++ b/lib/konacha/engine.rb
@@ -23,14 +23,15 @@ module Konacha
     initializer "konacha.environment" do |app|
       options = app.config.konacha
 
-      options.spec_dir     ||= "spec/javascripts"
-      options.spec_matcher ||= /_spec\.|_test\./
-      options.port         ||= 3500
-      options.application  ||= self.class.application(app)
-      options.driver       ||= :selenium
-      options.stylesheets  ||= %w(application)
-      options.verbose      ||= false
-      options.runner_port  ||= nil
+      options.spec_dir       ||= "spec/javascripts"
+      options.spec_matcher   ||= /_spec\.|_test\./
+      options.port           ||= 3500
+      options.application    ||= self.class.application(app)
+      options.driver         ||= :selenium
+      options.stylesheets    ||= %w(application)
+      options.verbose        ||= false
+      options.runner_port    ||= nil
+      options.iframe_economy ||= false
 
       app.config.assets.paths << app.root.join(options.spec_dir).to_s
     end

--- a/spec/models/spec_spec.rb
+++ b/spec/models/spec_spec.rb
@@ -50,6 +50,33 @@ describe Konacha::Spec do
       described_class.all("a").map(&:path).should == all[0..1]
     end
 
+    it "ignores grep matching config.iframe_economy is set to false" do
+      default_config = Konacha.config.iframe_economy
+      Konacha.config.iframe_economy = false
+      all = ["a_spec.js", "b_spec.js"]
+      Konacha.should_receive(:spec_paths) { all }
+      described_class.all(nil, "a").map(&:path).should == all
+      Konacha.config.iframe_economy = default_config
+    end
+
+    it "returns Specs that match a given grep" do
+      default_config = Konacha.config.iframe_economy
+      Konacha.config.iframe_economy = true
+      all = ["a_description_spec.js", "b_spec.js"]
+      Konacha.should_receive(:spec_paths) { all }
+      described_class.all(nil, "A description a specific test").map(&:path).should == [all[0]]
+      Konacha.config.iframe_economy = default_config
+    end
+
+    it "returns all Specs if given an empty grep" do
+      default_config = Konacha.config.iframe_economy
+      Konacha.config.iframe_economy = true
+      all = ["a_spec.js", "b_spec.js"]
+      Konacha.should_receive(:spec_paths) { all }
+      described_class.all(nil, nil).map(&:path).should == all
+      Konacha.config.iframe_economy = default_config
+    end
+
     it "raises NotFound if no Specs match" do
       Konacha.should_receive(:spec_paths) { [] }
       expect { described_class.all("b_spec") }.to raise_error(Konacha::Spec::NotFound)


### PR DESCRIPTION
Konacha loads all iframes even when running a single test.

This PR checks If `?grep` parameter is passed, and loads a single Iframe for the spec who's file name is included in the `grep` parameter.

Of course this requires naming convention (naming the file name same as the name of the spec).  That's why it's disabled by default, and if someone wants to use it, they can enable it and make sure all file names follow the convention.

The option is `iframe_economy`.
### What encouraged me to do this

I'm building a large Ember.js app with currently 300 javascript files ( that number will easily double when I complete the app )

Due to the large number of JS files and complex dependencies, `javascript_include_tag` takes around 3 seconds.  Multiply that by the number of specs (iframes) and the current Konacha test suite takes more than a minute to load.

Since Konacha loads all iframes when running a single test, I couldn't speed it up by running one test, which made my test suite basically unusable.

This PR doesn't solve the whole issue (i.e. it doesn't speed up running the entire test suite). So if you have any ideas or suggestions, I would be more than grateful. :)
