### PR TITLE
Support redirecting reporter output to a separate file

### DIFF
--- a/lib/konacha/engine.rb
+++ b/lib/konacha/engine.rb
@@ -20,13 +20,25 @@ module Konacha
       end
     end
 
+    def self.openOutput
+      if ENV['KONACHA_OUTPUT']
+        File.new(ENV['KONACHA_OUTPUT'], 'w')
+      else
+        STDOUT
+      end
+    end
+
+    def self.output
+      @output ||= openOutput
+    end
+
     def self.formatters
       if ENV['FORMAT']
         ENV['FORMAT'].split(',').map do |string|
-          eval(string).new(STDOUT)
+          eval(string).new(output)
         end
       else
-        [Konacha::Formatter.new(STDOUT)]
+        [Konacha::Formatter.new(output)]
       end
     end
 


### PR DESCRIPTION
I'd like to use yarjuf, rspec_junit_formatter, or ci_reporter - but this is currently very hard since poltergeist output is mixed with unit testing results.  This branch allows redirecting unit test output to a file. 
