### PR TITLE
Add extra_asset_paths configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,15 +190,46 @@ end if defined?(Konacha)
 The `defined?` check is necessary to avoid a dependency on Konacha in the production
 environment.
 
-The `spec_dir` option tells Konacha where to find JavaScript specs.  `spec_matcher`
-is an object responding to `===` (most likely a `Regexp`); it receives a filename
-and should return true if the file is a spec. `driver` names a Capybara driver used
-for the `run` task (try `:poltergeist`, after installing
-[PhantomJS](https://github.com/jonleighton/poltergeist#installing-phantomjs)).
-The `stylesheets` option sets the stylesheets to be linked from the `<head>`
-of the test runner iframe.
+Configuration options include:
 
-The values above are the defaults.
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th><code>driver</code></th>
+      <td><code>:selenium</code></td>
+      <td>Names a Capybara driver used for the <code>run</code> task (try
+<code>:poltergeist</code>, after installing <a href="https://github.com/jonleighton/poltergeist#installing-phantomjs">PhantomJS</a>).</td>
+    </tr>
+    <tr>
+      <th><code>extra_asset_paths</code></th>
+      <td></td>
+      <td>Adds asset paths when running the Konacha server. For example, try <code>%w(public/assets)</code> to make Konacha work with <a href="https://github.com/markbates/coffee-rails-source-maps">CoffeeScript Rails Source Maps</a>.</td>
+    </tr>
+    <tr>
+      <th><code>spec_dir</code></th>
+      <td><code>spec/javascripts</code></td>
+      <td>Tells Konacha where to find Javascript specs.</td>
+    </tr>
+    <tr>
+      <th><code>spec_matcher</code></th>
+      <td><code>/_spec\.|_test\./</code></td>
+      <td>An object responding to <code>===</code> (most likely a <code>Regexp</code>); it receives a filename and should return true if the file is a spec.</td>
+    </tr>
+    <tr>
+      <th><code>stylesheets</code></th>
+      <td><code>%w(application)</code></td>
+      <td>Sets the stylesheets to be linked from the <code>&lt;head&gt;</code> of the test runner iframe.</td>
+    </tr>
+  </tbody>
+</table>
+
 
 ## Test Interface and Assertions
 

--- a/lib/konacha/engine.rb
+++ b/lib/konacha/engine.rb
@@ -42,6 +42,11 @@ module Konacha
       options.verbose      ||= false
       options.runner_port  ||= nil
       options.formatters   ||= self.class.formatters
+      if options.extra_asset_paths
+        options.extra_asset_paths.each do |extra_asset_path|
+          app.config.assets.paths << app.root.join(extra_asset_path).to_s
+        end
+      end
 
       app.config.assets.paths << app.root.join(options.spec_dir).to_s
     end


### PR DESCRIPTION
We're experimenting with source maps in Konacha, and we needed to support extra asset paths to do it. I'd imagine this could come in handy in other ways, too.
