### PR TITLE
Adding an explicit exit 0 for jruby

### DIFF
--- a/lib/tasks/konacha.rake
+++ b/lib/tasks/konacha.rake
@@ -11,5 +11,7 @@ namespace :konacha do
     # throwing an exception or exiting.
     # http://stackoverflow.com/a/5117457/525872
     exit 1 unless passed
+    # Jruby seems to require an explicit exit 0
+    exit 0
   end
 end


### PR DESCRIPTION
Under Jruby the rake task seems to always return an exit code of 1. No idea why it's doing that, but it isn't exiting due to the passed check, so putting an explicit exit 0 afterwards fixed the issue for me.
