### PR TITLE
add an optional manifest file for general assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ mocha.timeout(5);
 chai.Assertion.includeStack = true;
 ```
 
+## Optional manifest file
+
+Any assets that are included in your `spec_helper` get loaded once for
+each spec which can lead to many time consuming requests. If you have
+assets that are used in all tests you can create a `manifest.js` or
+`manifest.js.coffee` in `app/assets/javascript/konacha` and include your
+assets there. This file is included once for each test. Please consider
+the next section before you decide to add all your assets to the
+`konacha/manifest`.
+
 ## Directives and Asset Bundling
 
 We suggest that you explicitly require just the assets necessary for each spec.

--- a/app/assets/javascripts/konacha/manifest.js
+++ b/app/assets/javascripts/konacha/manifest.js
@@ -1,0 +1,1 @@
+// This file is just here to make the manifest optional.

--- a/app/views/konacha/specs/iframe.html.erb
+++ b/app/views/konacha/specs/iframe.html.erb
@@ -9,7 +9,7 @@
       <%= stylesheet_link_tag file, :debug => false %>
     <% end %>
 
-    <%= javascript_include_tag "chai", "konacha/iframe", :debug => false %>
+    <%= javascript_include_tag "chai", "konacha/iframe", "konacha/manifest", :debug => false %>
     <%= javascript_include_tag @spec.asset_name %>
   </head>
   <body>


### PR DESCRIPTION
I ran across a [blog post](http://icu.iorahealth.com/blog/2013/05/31/speeding-up-the-konacha-javascript-testing-framework-with-views) about speeding up konacha. After playing around with it and seeing a big improvement in the speed of my tests I decided to check how come this hasn't been added. As far as I can see they never got around to making a pull request or perhaps you have already rejected it. In either case I decided to implement it in the way they suggested as I like the feature.

The basic idea is to cut down on asset requests by allowing the user to specify assets that don't need to be reloaded for each spec. This is done by adding a new manifest file (konacha/manifest.js) which is included in the iframe. Any files in there will only get requested once for each test instead of once for each spec.

Depending on the amount of assets in the spec_helper and the average amount of specs per test this can make a huge difference to the amount of time it takes to run the tests. Obviously this has the same pitfalls as adding assets to the spec_helper as well as some new ones, but if used properly I think it is a useful feature.

All credit goes to [Myke Cameron](https://github.com/mykecameron) as he proposed this solution.
