### PR TITLE
Extended metadata access for Example and ExampleGroup

### DIFF
--- a/lib/konacha/reporter/example.rb
+++ b/lib/konacha/reporter/example.rb
@@ -32,6 +32,10 @@ module Konacha
       def update_metadata(data)
         metadata.update(data)
       end
+
+      def [](key)
+        respond_to?(key) ? send(key) : metadata[key]
+      end
     end
   end
 end

--- a/lib/konacha/reporter/example_group.rb
+++ b/lib/konacha/reporter/example_group.rb
@@ -36,6 +36,10 @@ module Konacha
       def update_metadata(data)
         metadata.update(data)
       end
+
+      def [](key)
+        respond_to?(key) ? send(key) : metadata[key]
+      end
     end
   end
 end

--- a/spec/reporter/example_group_spec.rb
+++ b/spec/reporter/example_group_spec.rb
@@ -66,4 +66,21 @@ describe Konacha::Reporter::ExampleGroup do
       subject.update_metadata(data)
     end
   end
+
+  describe "#[]" do
+    it "should delegate to instance method if it exists" do
+      subject.stub(:some_method) { nil }
+      subject.stub(:metadata) { nil }
+      subject.should_receive(:some_method)
+      subject.should_not_receive(:metadata)
+      subject[:some_method]
+    end
+
+    it "should delegate to metadata if no method exists" do
+      subject.should_not respond_to(:some_method)
+      subject.metadata.stub(:[]) { nil }
+      subject.metadata.should_receive(:[]).with(:some_method)
+      subject[:some_method]
+    end
+  end
 end

--- a/spec/reporter/example_spec.rb
+++ b/spec/reporter/example_spec.rb
@@ -79,4 +79,21 @@ describe Konacha::Reporter::Example do
       subject.update_metadata(data)
     end
   end
+
+  describe "#[]" do
+    it "should delegate to instance method if it exists" do
+      subject.stub(:some_method) { nil }
+      subject.stub(:metadata) { nil }
+      subject.should_receive(:some_method)
+      subject.should_not_receive(:metadata)
+      subject[:some_method]
+    end
+
+    it "should delegate to metadata if no method exists" do
+      subject.should_not respond_to(:some_method)
+      subject.metadata.stub(:[]) { nil }
+      subject.metadata.should_receive(:[]).with(:some_method)
+      subject[:some_method]
+    end
+  end
 end


### PR DESCRIPTION
On trying to get Konacha working with [yarjuf](https://github.com/natritmeyer/yarjuf) JUnit spec output, I ran into some trouble due to differences in metadata handling for `Example` and `ExampleGroup` between RSpec and Konacha.

This PR is trying to address some of these issues, in particular:
- Merge `parent` metadata into Example and ExampleGroup metadata to allow metadata tree traversal up to root group
- Add `[]` Hash-like accessors to Example and ExampleGroup, delegating to instance method or metadata if no method exists
- Add `example_group` alias for `parent` on ExampleGroup (this was already implemented for Example, seemed to be missing)

Updates specs are included in each commit. I also tested this on an actual project with `konacha:run` and `konacha:serve` (with and without `yarjuf` JUnit reporting) and everything still seems to be running fine.

One thing I did notice, but decided not to do, is a possibility for DRYing up some duplicate code between Example and ExampleGroup. The `initialize`, `update_metadata` and `[]` methods could be moved into a shared Module and could then be tested separately (instead of copying specs over between both of them). I'd be happy to add this upon request.
