### PR TITLE
Allow configuration of iframes' javascript files

### DIFF
--- a/app/controllers/konacha/specs_controller.rb
+++ b/app/controllers/konacha/specs_controller.rb
@@ -12,6 +12,7 @@ module Konacha
     def iframe
       @spec = Konacha::Spec.find_by_name(params[:name])
       @stylesheets = Konacha::Engine.config.konacha.stylesheets
+      @javascripts = Konacha::Engine.config.konacha.javascripts
     end
   end
 end

--- a/app/views/konacha/specs/iframe.html.erb
+++ b/app/views/konacha/specs/iframe.html.erb
@@ -9,7 +9,7 @@
       <%= stylesheet_link_tag file, :debug => false %>
     <% end %>
 
-    <%= javascript_include_tag "chai", "konacha/iframe", :debug => false %>
+    <%= javascript_include_tag *@javascripts, :debug => false %>
     <%= javascript_include_tag @spec.asset_name %>
   </head>
   <body>

--- a/lib/konacha/engine.rb
+++ b/lib/konacha/engine.rb
@@ -39,6 +39,7 @@ module Konacha
       options.application  ||= self.class.application(app)
       options.driver       ||= :selenium
       options.stylesheets  ||= %w(application)
+      options.javascripts  ||= %w(chai konacha/iframe)
       options.verbose      ||= false
       options.runner_port  ||= nil
       options.formatters   ||= self.class.formatters

--- a/spec/controllers/specs_controller_spec.rb
+++ b/spec/controllers/specs_controller_spec.rb
@@ -23,6 +23,8 @@ describe Konacha::SpecsController do
       Konacha::Spec.should_receive(:find_by_name).with("spec_name") { :spec }
       get :iframe, :name => "spec_name"
       assigns[:spec].should == :spec
+      assigns[:stylesheets].should == Konacha::Engine.config.konacha.stylesheets
+      assigns[:javascripts].should == Konacha::Engine.config.konacha.javascripts
     end
 
     it "404s if there is no match for the given path" do

--- a/spec/views/specs/iframe.html.erb_spec.rb
+++ b/spec/views/specs/iframe.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe "konacha/specs/iframe" do
   before do
     assign(:stylesheets, [])
+    assign(:javascripts, [])
   end
 
   def spec_double(asset_name)
@@ -13,7 +14,8 @@ describe "konacha/specs/iframe" do
     assign(:spec, spec_double("a_spec"))
 
     view.stub(:javascript_include_tag)
-    view.should_receive(:javascript_include_tag).with("a_spec")
+    view.should_receive(:javascript_include_tag).with(:debug => false).ordered
+    view.should_receive(:javascript_include_tag).with("a_spec").ordered
 
     render
   end
@@ -24,6 +26,16 @@ describe "konacha/specs/iframe" do
 
     view.should_receive(:stylesheet_link_tag).with("foo", :debug => false)
     view.should_receive(:stylesheet_link_tag).with("bar", :debug => false)
+
+    render
+  end
+
+  it "renders the javascripts" do
+    assign(:spec, spec_double("a_spec"))
+    assign(:javascripts, %w(foo bar))
+
+    view.should_receive(:javascript_include_tag).with("foo", "bar", :debug => false).ordered
+    view.should_receive(:javascript_include_tag).with("a_spec").ordered
 
     render
   end


### PR DESCRIPTION
This PR is the same direction as #155. With this change, we could massively speed up our entire test suite. Around a factor of 10 to 20.

This change is fully compatible with the existing source as it only allows the linked javascript files in the `iframe.html.erb` to be configured.

By including a `spec_helper.js` file together with the `chai` and `konacha/iframe` we massively reduced the number of HTTP requests. Also sprockets only needs to compile the specs itself for every iframe as we can omit the `\\= require "spec_helper"` at the beginning of the spec files.
