### PR TITLE
Override mocha links to utilize the konacha path parameter.

### DIFF
--- a/app/assets/javascripts/konacha/parent.js
+++ b/app/assets/javascripts/konacha/parent.js
@@ -4,6 +4,23 @@ window.onload = function () {
     return a.path.localeCompare(b.path);
   });
 
+  var originalTestUrl = Mocha.reporters.HTML.prototype.testURL;
+
+  Mocha.reporters.HTML.prototype.suiteURL = function(suite) {
+    var specFilePath,
+        grepString = originalTestUrl(suite),
+        currentSuite = suite;
+
+    while (!(specFilePath = currentSuite.path)) {
+      currentSuite = currentSuite.parent
+    }
+
+    specFilePath = /([^\.]*)/.exec(specFilePath)[1];
+    return location.protocol+'//'+location.host+'/'+specFilePath+grepString;
+  };
+
+  Mocha.reporters.HTML.prototype.testURL = Mocha.reporters.HTML.prototype.suiteURL;
+
   // Check that all iframes loaded successfully.
   var iframes = document.getElementsByTagName('iframe');
   for (var i = 0; i < iframes.length; ++i) {

--- a/spec/dummy/spec/javascripts/empty_suite_and_test_spec.js.coffee
+++ b/spec/dummy/spec/javascripts/empty_suite_and_test_spec.js.coffee
@@ -1,0 +1,4 @@
+# Utilized in spec/mocha_links_spec
+describe "A test suite", ->
+  it "A known test name", ->
+    1.should.equal(1)

--- a/spec/mocha_links_spec.rb
+++ b/spec/mocha_links_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Konacha, type: :feature do
+  before { Konacha.mode = :server }
+
+  describe 'suite/test links' do
+    let(:spec_file)  { 'empty_suite_and_test_spec' }
+    let(:suite_name) { 'A test suite' }
+    let(:test_name)  { 'A known test name' }
+
+    before { visit '/' }
+
+    describe 'suite link' do
+      subject{ page.find_link('A test suite') }
+
+      it 'should contain spec path and grep string' do
+        subject['href'].should == "#{page.current_url}#{spec_file}?grep=#{URI.encode(suite_name)}"
+      end
+    end
+
+    describe 'replay link (arrow icon)' do
+      subject{ page.find(%Q{a[href="#{page.current_url}#{spec_file}?grep=#{URI.encode([suite_name, test_name].join(' '))}"]}) }
+
+      it 'should contain spec path and grep string' do
+        subject.should_not be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thus only the particular iframes for the mocha suite/test that was clicked will be rendered.

Result of conversion in [request #121](https://github.com/jfirebaugh/konacha/pull/121)
