### PR TITLE
Make mocha pre.error element vertically scrollable

### DIFF
--- a/app/assets/stylesheets/konacha.css
+++ b/app/assets/stylesheets/konacha.css
@@ -38,6 +38,14 @@ body {
   width: 40%;
 }
 
+pre.error {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 90%;
+  width: calc(100% - 42px);
+}
+
 
 @media (max-width: 1860px) {
   .test-context {


### PR DESCRIPTION
The error element is currently hiding behind iframe which makes it difficult see full stack trace.