### PR TITLE
removed precompiling

### DIFF
--- a/lib/konacha/engine.rb
+++ b/lib/konacha/engine.rb
@@ -45,7 +45,6 @@ module Konacha
       options.formatters   ||= self.class.formatters
 
       app.config.assets.paths << app.root.join(options.spec_dir).to_s
-      app.config.assets.precompile << lambda{|path| path =~ %r{\.(js|coffee)$} }
     end
   end
 end


### PR DESCRIPTION
adding additional assets to be precompiled interrupts any specific needs for the development environment.  is there any particular reason this is registering js/coffee files?  At the very least, it should only match konacha specific assets rather than all .js & .coffee.  IMO this is the responsibility of the parent application.
