### PR TITLE
Allow mutliple spec_dir entries

### DIFF
--- a/lib/konacha.rb
+++ b/lib/konacha.rb
@@ -32,17 +32,19 @@ module Konacha
     delegate :port, :spec_dir, :spec_matcher, :application, :driver, :runner_port, :formatters, :to => :config
 
     def spec_root
-      File.join(Rails.root, config.spec_dir)
+      [config.spec_dir].flatten.map {|d| File.join(Rails.root, d)}
     end
 
     def spec_paths
-      Rails.application.assets.each_entry(spec_root).find_all { |pathname|
-        config.spec_matcher === pathname.basename.to_s &&
-        (pathname.extname == '.js' || Tilt[pathname]) &&
-        Rails.application.assets.content_type_of(pathname) == 'application/javascript'
-      }.map { |pathname|
-        pathname.to_s.gsub(File.join(spec_root, ''), '')
-      }.sort
+      spec_root.flat_map {|root| 
+        Rails.application.assets.each_entry(root).find_all { |pathname|
+          config.spec_matcher === pathname.basename.to_s &&
+          (pathname.extname == '.js' || Tilt[pathname]) &&
+          Rails.application.assets.content_type_of(pathname) == 'application/javascript'
+        }.map { |pathname|
+          pathname.to_s.gsub(File.join(root, ''), '')
+        }.sort
+      }
     end
   end
 end

--- a/lib/konacha/engine.rb
+++ b/lib/konacha/engine.rb
@@ -44,7 +44,8 @@ module Konacha
       options.runner_port  ||= nil
       options.formatters   ||= self.class.formatters
 
-      app.config.assets.paths << app.root.join(options.spec_dir).to_s
+      spec_dirs = [options.spec_dir].flatten
+      app.config.assets.paths += spec_dirs.map{|d| app.root.join(d).to_s}
       app.config.assets.raise_runtime_errors = false
     end
   end

--- a/spec/dummy/app/sections/my_section/my_section.js.coffee
+++ b/spec/dummy/app/sections/my_section/my_section.js.coffee
@@ -1,0 +1,2 @@
+window.MySection =
+  number_one: -> 1

--- a/spec/dummy/app/sections/my_section/my_section_spec.js.coffee
+++ b/spec/dummy/app/sections/my_section/my_section_spec.js.coffee
@@ -1,0 +1,6 @@
+#= require ./my_section
+
+describe "MySection", ->
+  describe '#number_one', ->
+    it "returns 1", ->
+      MySection.number_one().should.equal 1

--- a/spec/konacha_spec.rb
+++ b/spec/konacha_spec.rb
@@ -98,6 +98,31 @@ describe Konacha do
         subject.size.should == 1
       end
     end
+
+    context 'with additional spec directories', focus: true do
+      around do |example|
+        begin
+          spec_dir = Konacha.config.spec_dir
+          Konacha.configure {|c| c.spec_dir = ["spec/javascripts", "app/sections"]}
+          example.run
+          Rails.application.config.assets.paths << Rails.root.join("app/sections").to_s
+        ensure
+          Konacha.configure {|c| c.spec_dir = spec_dir}
+
+        end
+      end
+
+      it 'has specs from spec/javascripts' do
+        subject.should include("array_sum_js_spec.js")
+        subject.should include("array_sum_cs_spec.js.coffee")
+      end
+
+      it 'has specs from app/sections' do
+        Konacha.spec_root.should include Rails.root.join("app/sections").to_s
+        subject.should include("my_section/my_section_spec.js.coffee")
+      end
+    end
+
   end
 
   it "can be configured in an initializer" do


### PR DESCRIPTION
The primary motivation here is to add support for alternative asset path setups as in [sections_rails](https://github.com/kevgo/sections_rails). Specifically, my use case is that I need the specs for my sections to live with the section they belong in, but I also have shared javascript assets and specs that should live in spec/javascripts and app/assets/javascripts (e.g., models, shared views)
