### PR TITLE
Use root namespace for Rails::Engine

### DIFF
--- a/lib/konacha/engine.rb
+++ b/lib/konacha/engine.rb
@@ -1,5 +1,5 @@
 module Konacha
-  class Engine < Rails::Engine
+  class Engine < ::Rails::Engine
     # Do not mess up the application's namespace.
     # http://api.rubyonrails.org/classes/Rails/Engine.html#label-Isolated+Engine
     isolate_namespace Konacha


### PR DESCRIPTION
As guide in http://guides.rubyonrails.org/engines.html otherwise I get `Uninitialized constant Konacha::Rails` when requiring it