### PR TITLE
Rails 4.2.1 compatibility issue: Sprockets::Base#each_entry is no longer present.

### DIFF
--- a/konacha.gemspec
+++ b/konacha.gemspec
@@ -22,7 +22,7 @@ the asset pipeline and engines.}
 
   gem.add_dependency "railties", ">= 3.1", "< 5"
   gem.add_dependency "actionpack", ">= 3.1", "< 5"
-  gem.add_dependency "sprockets"
+  gem.add_dependency "sprockets", "= 2.12.3"
   gem.add_dependency "capybara"
   gem.add_dependency "colorize"
 


### PR DESCRIPTION
A new Rails application will use the latest Sprockets up to version 4.0. `Konacha#spec_paths` uses `Rails.application.assets.each_entry`, which was removed after version 2.12.3. Fortunately Rails is compatible with versions 2.8 to 4.0 of Sprockets, so I fixed this issue by locking Konacha into Sprockets version 2.12.3 so it will work with Rails 4.2.1.

You might want to consider moving away from using `Sprockets::Base#each_entry` in a future release so the gem will work with the latest Sprockets.