### PR TITLE
Only return spec paths that are in spec directories (in sprockets 3)

### DIFF
--- a/lib/konacha.rb
+++ b/lib/konacha.rb
@@ -48,7 +48,8 @@ module Konacha
         elsif Rails.application.assets.respond_to?(:each_file)
           paths = Rails.application.assets.each_file.find_all { |path|
             pathname = Pathname.new(path)
-            config.spec_matcher === pathname.basename.to_s &&
+            pathname.dirname.to_s.start_with?(root) &&
+              config.spec_matcher === pathname.basename.to_s &&
               (pathname.extname == '.js' || Tilt[pathname])
           }
         else

--- a/spec/konacha_spec.rb
+++ b/spec/konacha_spec.rb
@@ -99,7 +99,7 @@ describe Konacha do
       end
     end
 
-    context 'with additional spec directories' do
+    context 'with configured spec directories' do
       around do |example|
         begin
           spec_dir = Konacha.config.spec_dir
@@ -107,9 +107,11 @@ describe Konacha do
           # For Sprockets 3, adding to config.assets.paths does not work
           if Rails.application.assets.respond_to?(:append_path)
             Rails.application.assets.append_path(Rails.root.join("app/sections").to_s)
+            Rails.application.assets.append_path(Rails.root.join("spec/isolated").to_s)
           # Sprockets 2
           else
             Rails.application.config.assets.paths << Rails.root.join("app/sections").to_s
+            Rails.application.config.assets.paths << Rails.root.join("spec/isolated").to_s
           end
           example.run
         ensure
@@ -126,6 +128,16 @@ describe Konacha do
       it 'has specs from app/sections' do
         Konacha.spec_root.should include Rails.root.join("app/sections").to_s
         subject.should include("my_section/my_section_spec.js.coffee")
+      end
+
+      # spec/isolated is in the assets path, but not Koncha's spec_dir
+      it 'does not have specs from spec/isolated' do
+        Konacha.spec_root.should_not include Rails.root.join("spec/isolated").to_s
+
+        spec_file = "isolated/errors/failing_iframe_spec.js.coffee"
+        # Ensure neither the relative or absolute paths are present
+        subject.should_not include(spec_file)
+        subject.should_not include(Rails.root.join("spec", spec_file).to_s)
       end
     end
 


### PR DESCRIPTION
This fixes what I believe to be a regression from the behaviour with sprockets 2.

When using sprockets 2, `Konacha.spec_paths` only returns spec files within the configured `spec_dir`s, whereas when using sprockets 3 it returns all spec files in any rails asset path.

This is causing problems for us because we have legacy javascript specs in our asset path that we don't want to test using konacha. These specs are not in a spec_dir and were being ignored by konacha until we upgraded sprockets.

I'm happy to provide a cleaner implementation if you agree with the fix in principle (for example, there's no need to iterate through spec_root in sprockets 3)