### PR TITLE
Add Support for Sprocket Rails 3.0

### DIFF
--- a/konacha.gemspec
+++ b/konacha.gemspec
@@ -17,7 +17,7 @@ the asset pipeline and engines.}
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "konacha"
   gem.require_paths = ["lib"]
-  gem.version       = "3.7.0"
+  gem.version       = "3.8.0"
   gem.license       = "MIT"
 
   gem.add_dependency "railties", ">= 3.1", "< 5"


### PR DESCRIPTION
This should be compatible with the following:
- Rails 4.2, sprockets 3, sprockets-rails 3
- Rails 4.1, sprockets 3, sprockets-rails 3
- Rails 4.2, sprockets 2, sprockets-rails 2
- Rails 4.2, sprockets 3, sprockets-rails 2

This is based on the work that  @alexkravets did and resulted in https://github.com/jfirebaugh/konacha/pull/219. My commits (which could be cleaned up) makes all of it backwards compatible with sprockets-rails-2 (all the way to 2.0.0) and sprockets 3.
