### PR TITLE
Prevent IE from switching to compatible view.

### DIFF
--- a/app/views/konacha/specs/parent.html.erb
+++ b/app/views/konacha/specs/parent.html.erb
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="content-type" content="text/html;charset=utf-8" />
     <title>Konacha Tests</title>
     <%= stylesheet_link_tag "konacha", :debug => false %>


### PR DESCRIPTION
IE8 (maybe other versions, too) switch to the Compatibility View when an error is encountered. Prevent this.
