### PR TITLE
Replace body

### DIFF
--- a/app/assets/javascripts/konacha/iframe.js
+++ b/app/assets/javascripts/konacha/iframe.js
@@ -1,6 +1,9 @@
 window.Konacha = {
   reset: function() {
-    document.body = document.createElement('body');
+    document.body.parentNode.replaceChild(
+      document.createElement('body'),
+      document.body
+    );
     document.body.id = 'konacha';
   }
 };

--- a/app/views/konacha/specs/parent.html.erb
+++ b/app/views/konacha/specs/parent.html.erb
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="content-type" content="text/html;charset=utf-8" />
     <title>Konacha Tests</title>
     <%= stylesheet_link_tag "konacha", :debug => false %>


### PR DESCRIPTION
Before loading a suite Konacha replaces the `body` element to have a clean slate:

``` js
document.body = document.createElement('body');
```

However, IE8 does not support this and throws a `Member not found.` error. Instead of assigning a new body element replace the current element in place. This seems to satisfy all browsers, even IE8.
