### PR TITLE
Add config option 'runner_host' to pass a host to Capybara

### DIFF
--- a/lib/konacha.rb
+++ b/lib/konacha.rb
@@ -29,7 +29,8 @@ module Konacha
       yield config
     end
 
-    delegate :host, :port, :spec_dir, :spec_matcher, :application, :driver, :runner_port, :formatters, :to => :config
+    delegate :host, :port, :spec_dir, :spec_matcher, :application, :driver,
+             :runner_host, :runner_port, :formatters, :to => :config
 
     def spec_root
       [config.spec_dir].flatten.map {|d| File.join(Rails.root, d)}

--- a/lib/konacha/engine.rb
+++ b/lib/konacha/engine.rb
@@ -45,6 +45,7 @@ module Konacha
       options.stylesheets  ||= %w(application)
       options.javascripts  ||= %w(chai konacha/iframe)
       options.verbose      ||= false
+      options.runner_host  ||= nil
       options.runner_port  ||= nil
       options.formatters   ||= self.class.formatters
 

--- a/lib/konacha/runner.rb
+++ b/lib/konacha/runner.rb
@@ -3,6 +3,7 @@ require "capybara"
 module Konacha
   class Runner
     def self.start
+      Capybara.server_host = Konacha.runner_host
       Capybara.server_port = Konacha.runner_port
       new.run
     end

--- a/spec/konacha_spec.rb
+++ b/spec/konacha_spec.rb
@@ -16,6 +16,12 @@ describe Konacha do
       end
     end
 
+    describe ".runner_host" do
+      it "defaults to nil" do
+        subject.runner_host.should == nil
+      end
+    end
+
     describe ".runner_port" do
       it "defaults to nil" do
         subject.runner_port.should == nil

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -19,6 +19,12 @@ describe Konacha::Runner do
   end
 
   describe ".start" do
+    it 'sets the Capybara.server_host' do
+      Capybara.should_receive(:server_host=).with(Konacha.runner_host)
+      Konacha::Runner.any_instance.stub(:run)
+      Konacha::Runner.start
+    end
+
     it 'sets the Capybara.server_port' do
       Capybara.should_receive(:server_port=).with(Konacha.runner_port)
       Konacha::Runner.any_instance.stub(:run)


### PR DESCRIPTION
This is useful if e.g. a remote selenium installation is used.